### PR TITLE
feat: content negotiation JSON/YAML/CBOR & GZip/Brotli

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A modern, simple, fast & opinionated REST API framework for Go with batteries in
 
 - A modern REST API backend framework for Go developers
   - Described by [OpenAPI 3](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md) & [JSON Schema](https://json-schema.org/)
-  - First class support for middleware, JSON, and other features
+  - First class support for middleware, JSON/CBOR, and other features
 - Guard rails to prevent common mistakes
 - Documentation that can't get out of date
 - High-quality developer tooling
@@ -29,6 +29,9 @@ Features include:
   - Structured logging middleware using [Zap](https://github.com/uber-go/zap)
   - Automatic handling of `Prefer: return=minimal` from [RFC 7240](https://tools.ietf.org/html/rfc7240#section-4.2)
 - Per-operation request size limits & timeouts with sane defaults
+- [Content negotiation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation) between server and client
+  - Support for GZip ([RFC 1952](https://tools.ietf.org/html/rfc1952)) & Brotli ([RFC 7932](https://tools.ietf.org/html/rfc7932)) content encoding via the `Accept-Encoding` header.
+  - Support for JSON ([RFC 8259](https://tools.ietf.org/html/rfc8259)), YAML, and CBOR ([RFC 7049](https://tools.ietf.org/html/rfc7049)) content types via the `Accept` header.
 - Annotated Go types for input and output models
   - Generates JSON Schema from Go types
   - Automatic input model validation & error handling
@@ -615,7 +618,6 @@ g.Use(huma.ServiceLinkMiddleware())
 g.NoRoute(huma.Handler404())
 r := huma.NewRouter("My API", "1.0.0", huma.WithGin(g))
 ```
-
 
 ## Custom CORS Handler
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.13
 
 require (
 	github.com/Jeffail/gabs v1.4.0
+	github.com/andybalholm/brotli v1.0.0
 	github.com/fatih/structs v1.1.0
+	github.com/fxamacker/cbor/v2 v2.2.0
 	github.com/getkin/kin-openapi v0.3.0
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-gonic/autotls v0.0.0-20200314141124-cc69476aef2a

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/Jeffail/gabs v1.4.0/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/andybalholm/brotli v1.0.0 h1:7UCwP93aiSfvWpapti8g88vVVGp2qqtGyePsSuDafo4=
+github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -26,6 +28,8 @@ github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fxamacker/cbor/v2 v2.2.0 h1:6eXqdDDe588rSYAi1HfZKbx6YYQO4mxQ9eC6xYpU/JQ=
+github.com/fxamacker/cbor/v2 v2.2.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/getkin/kin-openapi v0.3.0 h1:xsQ4mA20YJDMgIHdHqMKZ66QUe6/hi+x6yLsTTz8xyQ=
 github.com/getkin/kin-openapi v0.3.0/go.mod h1:W8dhxZgpE84ciM+VIItFqkmZ4eHtuomrdIHtASQIqi0=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
@@ -175,6 +179,8 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/fasttemplate v1.1.0 h1:RZqt0yGBsps8NGvLSGW804QQqCUYYLsaOjTVHy1Ocw4=
 github.com/valyala/fasttemplate v1.1.0/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=

--- a/middelware.go
+++ b/middelware.go
@@ -2,16 +2,21 @@ package huma
 
 import (
 	"bytes"
+	"compress/gzip"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"os"
+	"path"
 	"runtime/debug"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/andybalholm/brotli"
 	"github.com/gin-gonic/gin"
 	"github.com/mattn/go-isatty"
 	"go.uber.org/zap"
@@ -306,6 +311,183 @@ func ServiceLinkMiddleware() Middleware {
 		if c.Request.URL.Path == "/" {
 			AddServiceLinks(c)
 		}
+		c.Next()
+	}
+}
+
+// selectQValue selects and returns the best value from the allowed set
+// given a header with optional quality values, as you would get for an
+// Accept or Accept-Encoding header. The *first* item in allowed is preferred
+// if there is a tie. If nothing matches, returns an empty string.
+func selectQValue(header string, allowed []string) string {
+	formats := strings.Split(header, ",")
+	best := ""
+	bestQ := 0.0
+	for _, format := range formats {
+		parts := strings.Split(format, ";")
+		name := strings.Trim(parts[0], " \t")
+
+		found := false
+		for _, n := range allowed {
+			if n == name {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			// Skip formats we don't support.
+			continue
+		}
+
+		// Default weight to 1 if no value is passed.
+		q := 1.0
+		if len(parts) > 1 {
+			trimmed := strings.Trim(parts[1], " \t")
+			if strings.HasPrefix(trimmed, "q=") {
+				q, _ = strconv.ParseFloat(trimmed[2:], 64)
+			}
+		}
+
+		// Prefer the first one if there is a tie.
+		if q > bestQ || (q == bestQ && name == allowed[0]) {
+			bestQ = q
+			best = name
+		}
+	}
+
+	return best
+}
+
+type contentEncodingWriter struct {
+	gin.ResponseWriter
+	status      int
+	encoding    string
+	buf         *bytes.Buffer
+	writer      io.Writer
+	minSize     int
+	gzPool      *sync.Pool
+	brPool      *sync.Pool
+	wroteHeader bool
+}
+
+func (w *contentEncodingWriter) Write(data []byte) (int, error) {
+	if w.writer != nil {
+		// We are writing compressed data.
+		return w.writer.Write(data)
+	}
+
+	// Buffer the data until we can decide whether to compress it or not.
+	w.buf.Write(data)
+
+	cl, _ := strconv.Atoi(w.Header().Get("Content-Length"))
+	if cl >= w.minSize || w.buf.Len() >= w.minSize {
+		// We reached out minimum compression size. Set the writer, write the buffer
+		// and make sure to set the correct headers.
+		switch w.encoding {
+		case "gzip":
+			gz := w.gzPool.Get().(*gzip.Writer)
+			gz.Reset(w.ResponseWriter)
+			w.writer = gz
+		case "br":
+			br := w.brPool.Get().(*brotli.Writer)
+			br.Reset(w.ResponseWriter)
+			w.writer = br
+		}
+		w.Header().Set("Content-Encoding", w.encoding)
+		w.Header().Set("Vary", "Accept-Encoding")
+		w.ResponseWriter.WriteHeader(w.status)
+		w.wroteHeader = true
+		bufData := w.buf.Bytes()
+		w.buf.Reset()
+		return w.writer.Write(bufData)
+	}
+
+	// Not sure yet whether this should be compressed.
+	return len(data), nil
+}
+
+func (w *contentEncodingWriter) WriteHeader(code int) {
+	w.Header().Del("Content-Length")
+	w.status = code
+}
+
+func (w *contentEncodingWriter) Close() {
+	if !w.wroteHeader {
+		w.ResponseWriter.WriteHeader(w.status)
+	}
+
+	if w.buf.Len() > 0 {
+		w.ResponseWriter.Write(w.buf.Bytes())
+	}
+
+	if w.writer != nil {
+		if wc, ok := w.writer.(io.WriteCloser); ok {
+			wc.Close()
+		}
+	}
+}
+
+// ContentEncodingMiddleware uses content negotiation with the client to pick
+// an appropriate encoding (compression) method and transparently encodes
+// the response. Supports GZip and Brotli.
+func ContentEncodingMiddleware() Middleware {
+	// Use pools to reduce allocations. We use a byte buffer to temporarily store
+	// some of each response in order to determine whether compression should
+	// be applied. The others are just re-using the GZip and Brotli compressors.
+	bufPool := sync.Pool{
+		New: func() interface{} {
+			return new(bytes.Buffer)
+		},
+	}
+
+	gzPool := sync.Pool{
+		New: func() interface{} {
+			return gzip.NewWriter(ioutil.Discard)
+		},
+	}
+
+	brPool := sync.Pool{
+		New: func() interface{} {
+			return brotli.NewWriter(ioutil.Discard)
+		},
+	}
+
+	return func(c *gin.Context) {
+		if ext := path.Ext(c.Request.URL.Path); ext == ".gif" || ext == ".png" || ext == ".jpg" || ext == ".jpeg" || ext == ".zip" {
+			c.Next()
+			return
+		}
+
+		if ac := c.Request.Header.Get("Accept-Encoding"); ac != "" {
+			best := selectQValue(ac, []string{"br", "gzip"})
+
+			if best != "" {
+				buf := bufPool.Get().(*bytes.Buffer)
+				buf.Reset()
+				defer bufPool.Put(buf)
+
+				cew := &contentEncodingWriter{
+					ResponseWriter: c.Writer,
+					encoding:       best,
+					buf:            buf,
+					gzPool:         &gzPool,
+					brPool:         &brPool,
+
+					// minSize of the body at which compression is enabled. Internet MTU
+					// size is 1500 bytes, so anything smaller will still require sending
+					// at least that size. 1400 seems to be a sane default.
+					minSize: 1400,
+				}
+				// Status/headers are cached before any data is sent. Calling
+				// ensureHeaders makes sure we always send the headers, even for 204
+				// responses with no content. It's safe to call even if data was
+				// written, in which case this is a no-op.
+				defer cew.Close()
+				c.Writer = cew
+			}
+		}
+
 		c.Next()
 	}
 }

--- a/middleware.go
+++ b/middleware.go
@@ -359,6 +359,12 @@ func selectQValue(header string, allowed []string) string {
 	return best
 }
 
+const gzipEncoding = "gzip"
+const brotliEncoding = "br"
+
+var supportedEncodings []string = []string{brotliEncoding, gzipEncoding}
+var compressDenyList []string = []string{".gif", ".png", ".jpg", ".jpeg", ".zip", ".gz", ".bz2"}
+
 type contentEncodingWriter struct {
 	gin.ResponseWriter
 	status      int
@@ -382,14 +388,14 @@ func (w *contentEncodingWriter) Write(data []byte) (int, error) {
 
 	cl, _ := strconv.Atoi(w.Header().Get("Content-Length"))
 	if cl >= w.minSize || w.buf.Len() >= w.minSize {
-		// We reached out minimum compression size. Set the writer, write the buffer
+		// We reached our minimum compression size. Set the writer, write the buffer
 		// and make sure to set the correct headers.
 		switch w.encoding {
-		case "gzip":
+		case gzipEncoding:
 			gz := w.gzPool.Get().(*gzip.Writer)
 			gz.Reset(w.ResponseWriter)
 			w.writer = gz
-		case "br":
+		case brotliEncoding:
 			br := w.brPool.Get().(*brotli.Writer)
 			br.Reset(w.ResponseWriter)
 			w.writer = br
@@ -425,6 +431,14 @@ func (w *contentEncodingWriter) Close() {
 		if wc, ok := w.writer.(io.WriteCloser); ok {
 			wc.Close()
 		}
+
+		// Return the writer to the pool so it can be reused.
+		switch w.encoding {
+		case gzipEncoding:
+			w.gzPool.Put(w.writer)
+		case brotliEncoding:
+			w.brPool.Put(w.writer)
+		}
 	}
 }
 
@@ -454,13 +468,18 @@ func ContentEncodingMiddleware() Middleware {
 	}
 
 	return func(c *gin.Context) {
-		if ext := path.Ext(c.Request.URL.Path); ext == ".gif" || ext == ".png" || ext == ".jpg" || ext == ".jpeg" || ext == ".zip" {
-			c.Next()
-			return
+		if ext := path.Ext(c.Request.URL.Path); ext != "" {
+			for _, deny := range compressDenyList {
+				if ext == deny {
+					// This is a file type we should not try to compress.
+					c.Next()
+					return
+				}
+			}
 		}
 
 		if ac := c.Request.Header.Get("Accept-Encoding"); ac != "" {
-			best := selectQValue(ac, []string{"br", "gzip"})
+			best := selectQValue(ac, supportedEncodings)
 
 			if best != "" {
 				buf := bufPool.Get().(*bytes.Buffer)
@@ -479,10 +498,10 @@ func ContentEncodingMiddleware() Middleware {
 					// at least that size. 1400 seems to be a sane default.
 					minSize: 1400,
 				}
-				// Status/headers are cached before any data is sent. Calling
-				// ensureHeaders makes sure we always send the headers, even for 204
-				// responses with no content. It's safe to call even if data was
-				// written, in which case this is a no-op.
+				// Since we aren't sure if we will be compressing the response (due
+				// to size), here we trigger a call to close the writer after all
+				// writes have completed. This will send the status/headers and flush
+				// any buffers as needed.
 				defer cew.Close()
 				c.Writer = cew
 			}

--- a/openapi.go
+++ b/openapi.go
@@ -404,7 +404,7 @@ func (r *Router) OpenAPI() *gabs.Container {
 				headerMap[header.Name] = header
 			}
 
-			for _, resp := range op.responses {
+			for _, resp := range responses {
 				status := fmt.Sprintf("%v", resp.StatusCode)
 				openapi.Set(resp.Description, "paths", path, method, "responses", status, "description")
 

--- a/router.go
+++ b/router.go
@@ -63,9 +63,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/istreamlabs/huma/schema"
+	"github.com/fxamacker/cbor/v2"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
+	"github.com/istreamlabs/huma/schema"
 	"github.com/spf13/cobra"
 	"github.com/xeipuuv/gojsonschema"
 	"go.uber.org/zap"
@@ -338,6 +339,7 @@ func NewRouter(docs, version string, options ...RouterOption) *Router {
 	g.Use(LogMiddleware())
 	g.Use(PreferMinimalMiddleware())
 	g.Use(ServiceLinkMiddleware())
+	g.Use(ContentEncodingMiddleware())
 	g.NoRoute(Handler404())
 
 	title, desc := splitDocs(docs)
@@ -623,10 +625,36 @@ func (r *Router) register(method, path string, op *openAPIOperation) {
 					}
 				}
 
-				if strings.HasPrefix(r.ContentType, "application/json") || strings.HasSuffix(r.ContentType, "+json") {
+				ct := r.ContentType
+
+				// Allow content-negotiation to override the default for known structured
+				// responses.
+				if strings.Contains(ct, "json") || strings.Contains(ct, "yaml") || strings.Contains(ct, "cbor") {
+					if accept := c.GetHeader("Accept"); accept != "" {
+						best := selectQValue(accept, []string{"application/cbor", "application/json", "application/yaml", "application/x-yaml"})
+						if best != "" {
+							ct = best
+						}
+					}
+				}
+
+				if strings.HasPrefix(ct, "application/json") || strings.HasSuffix(ct, "+json") {
 					c.JSON(r.StatusCode, body)
-				} else if strings.HasPrefix(r.ContentType, "application/yaml") || strings.HasSuffix(r.ContentType, "+yaml") {
+				} else if strings.HasPrefix(ct, "application/yaml") || strings.HasPrefix(ct, "application/x-yaml") || strings.HasSuffix(ct, "+yaml") {
 					c.YAML(r.StatusCode, body)
+				} else if strings.HasPrefix(ct, "application/cbor") || strings.HasSuffix(ct, "+cbor") {
+					opts := cbor.CanonicalEncOptions()
+					opts.Time = cbor.TimeRFC3339Nano
+					opts.TimeTag = cbor.EncTagRequired
+					mode, err := opts.EncMode()
+					if err != nil {
+						panic(err)
+					}
+					m, err := mode.Marshal(body)
+					if err != nil {
+						panic(err)
+					}
+					c.Data(r.StatusCode, ct, m)
 				} else {
 					if o.Kind() == reflect.Ptr {
 						// This is a pointer to something, so we derefernce it and get
@@ -634,7 +662,7 @@ func (r *Router) register(method, path string, op *openAPIOperation) {
 						// by default print pointer addresses instead of their value.
 						body = o.Elem().Interface()
 					}
-					c.Data(r.StatusCode, r.ContentType, []byte(fmt.Sprintf("%v", body)))
+					c.Data(r.StatusCode, ct, []byte(fmt.Sprintf("%v", body)))
 				}
 				break
 			}

--- a/router_test.go
+++ b/router_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -23,6 +24,7 @@ import (
 
 func init() {
 	gin.SetMode(gin.TestMode)
+	os.Setenv("SERVICE_HOST", "127.0.0.1")
 }
 
 func ExampleNewRouter_customGin() {

--- a/router_test.go
+++ b/router_test.go
@@ -609,3 +609,88 @@ func TestRouterUnsafeHandler(t *testing.T) {
 	r.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 }
+
+func TestContentNegotiationYAML(t *testing.T) {
+	r := NewTestRouter(t)
+
+	type TestResponse struct {
+		Hello string `json:"hello"`
+	}
+
+	r.Resource("/").Get("test", func() *TestResponse {
+		return &TestResponse{
+			Hello: "world",
+		}
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Accept", "application/yaml")
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "yaml")
+	assert.Equal(t, "hello: world\n", w.Body.String())
+}
+
+func TestContentNegotiationCBOR(t *testing.T) {
+	r := NewTestRouter(t)
+
+	type TestResponse struct {
+		Hello string `json:"hello"`
+	}
+
+	r.Resource("/").Get("test", func() *TestResponse {
+		return &TestResponse{
+			Hello: "world",
+		}
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Accept", "application/cbor")
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "cbor")
+}
+
+func TestContentNegotiationStar(t *testing.T) {
+	r := NewTestRouter(t)
+
+	type TestResponse struct {
+		Hello string `json:"hello"`
+	}
+
+	r.Resource("/").Get("test", func() *TestResponse {
+		return &TestResponse{
+			Hello: "world",
+		}
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Accept", "*")
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "json")
+}
+
+func TestContentNegotiationMultiple(t *testing.T) {
+	r := NewTestRouter(t)
+
+	type TestResponse struct {
+		Hello string `json:"hello"`
+	}
+
+	r.Resource("/").Get("test", func() *TestResponse {
+		return &TestResponse{
+			Hello: "world",
+		}
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Accept", "application/cbor, application/yaml")
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "cbor")
+}


### PR DESCRIPTION
This pulls in some in-progress work of mine from before the fork that I finished up this weekend. I think this was the last major feature I was still working on. Specifically:

- Added support for `Accept-Encoding` content negotiation so that clients can tell the server they support compression. Both GZip and Brotli are supported but will *only* be used when the response size > 1400 bytes, due to the Internet MTU typically being 1500 bytes so anything smaller may use 1500 bytes anyway and isn't worth the CPU effort. See e.g. [Why it Doesn't Make Sense to GZIP All Content](https://www.itworld.com/article/2693941/why-it-doesn-t-make-sense-to-gzip-all-content-from-your-web-server.html) and [The GZIP Penalty](https://medium.com/@joehonton/the-gzip-penalty-d31bd697f1a2). Both compressor libraries use the default settings, which are a good mix of CPU-use vs. compression efficiency trade-off. We could add options to make this configurable in the future (out of scope for this sync PR).

- Added support for `Accept` content negotiation so that clients can request a certain preferred response format. Currently supported are JSON, YAML, and [CBOR](http://cbor.io/). CBOR is interesting because it natively supports dates and binary data (e.g. gives a 30% improvement over using base64 for SCTE-35). With server support we can offer our customers choice and experiment with what is best. Any `huma.ResponseJSON` supports this style of content negotiation at runtime. It is *deliberately* not documented in the OpenAPI because the documentation generators don't deal that well with non-JSON formats. This is left as a future TODO once we have our iSP documentation generator and portal built or we can improve third-party documentation libraries.

- Both changes have 100% code coverage and add several new tests.

- Fixes a tiny bug in `openapi.go` where generated 400 responses were not getting documented properly.

The reason this wasn't implemented before today is that we didn't have a good client to test with and start using these advanced features. Restish supports them out of the box so now felt like a good time to finish up the server side of things. This will likely also influence how we build our SDKs.

Side note: I went with my own implementation of the compression middleware because the existing ones for Gin all suck. Either they don't use a compressor pool or don't support a minimum compression byte threshold (again making sense to use a buffer pool to amortize allocation costs and limit garbage collection). I also wanted to support both GZip and Brotli. I based my work on the excellent NY Times package for the low-level http library: https://github.com/nytimes/gziphandler