### PR TITLE
fix: return correct status to other middleware

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -418,6 +418,10 @@ func (w *contentEncodingWriter) WriteHeader(code int) {
 	w.status = code
 }
 
+func (w *contentEncodingWriter) Status() int {
+	return w.status
+}
+
 func (w *contentEncodingWriter) Close() {
 	if !w.wroteHeader {
 		w.ResponseWriter.WriteHeader(w.status)


### PR DESCRIPTION
Fixes a bug where the wrong status code would get reported in loggers, metrics, and APM traces.