### PR TITLE
fix(ktracer/bp-171-nilvalue): add meaningful error message if param has nil-type

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/istreamlabs/huma/schema"
 	"github.com/gosimple/slug"
+	"github.com/istreamlabs/huma/schema"
 )
 
 // ErrAPIInvalid is returned when validating the OpenAPI top-level fields
@@ -146,7 +146,11 @@ func (o *openAPIOperation) validate(method, path string) {
 		if !(handler.NumIn() == totalIn || (method != http.MethodGet && handler.NumIn() == totalIn+1)) || handler.NumOut() != totalOut {
 			expected := "func("
 			for _, dep := range o.dependencies {
-				expected += "? " + reflect.ValueOf(dep.handler).Type().String() + ", "
+				val := reflect.ValueOf(dep.handler)
+				if !val.IsValid() {
+					panic(fmt.Errorf("dependency %s is not a valid type: %w", dep.handler, ErrParamInvalid))
+				}
+				expected += "? " + val.Type().String() + ", "
 			}
 			for _, param := range o.params {
 				expected += param.Name + " ?, "

--- a/validate_test.go
+++ b/validate_test.go
@@ -59,6 +59,20 @@ func TestOperationHandlerInput(t *testing.T) {
 	})
 }
 
+func TestOperationBadHandler(t *testing.T) {
+	r := NewTestRouter(t)
+
+	assert.Panics(t, func() {
+		r.Resource("/",
+			SimpleDependency(nil),
+			ResponseText(200, "Test"),
+		).Get("Test", func(pa *string, b int) string {
+			// Wrong number of inputs!
+			return "boom"
+		})
+	})
+}
+
 func TestOperationHandlerOutput(t *testing.T) {
 	r := NewTestRouter(t)
 


### PR DESCRIPTION
If an operation parameter is declared but not populated, then `dep.handler` will be `nil` and `reflect.ValueOf(dep.handler)` will return the zero `Value{}`. This guarantees a panic when `Type()` is called on it. Before calling `Type()`, we should check whether `reflect.ValueOf(dep.handler).IsValid()` and panic with a meaningful error if it's false.