### PR TITLE
fix: security reference structure

### DIFF
--- a/router.go
+++ b/router.go
@@ -39,7 +39,7 @@ type Router struct {
 	contact         oaContact
 	servers         []oaServer
 	securitySchemes map[string]oaSecurityScheme
-	security        map[string][]string
+	security        []map[string][]string
 
 	autoConfig *AutoConfig
 
@@ -160,9 +160,16 @@ func (r *Router) AutoConfig(autoConfig AutoConfig) {
 
 // SecurityRequirement sets up a security requirement for the entire API by
 // name and with the given scopes. Use together with the other auth options
-// like GatewayAuthCode.
+// like GatewayAuthCode. Calling multiple times results in requiring one OR
+// the other schemes but not both.
 func (r *Router) SecurityRequirement(name string, scopes ...string) {
-	r.security[name] = scopes
+	if scopes == nil {
+		scopes = []string{}
+	}
+
+	r.security = append(r.security, map[string][]string{
+		name: scopes,
+	})
 }
 
 // Resource creates a new resource attached to this router at the given path.
@@ -324,7 +331,7 @@ func New(docs, version string) *Router {
 		version:         version,
 		servers:         []oaServer{},
 		securitySchemes: map[string]oaSecurityScheme{},
-		security:        map[string][]string{},
+		security:        []map[string][]string{},
 	}
 
 	r.docsHandler = RapiDocHandler(r)

--- a/router_test.go
+++ b/router_test.go
@@ -264,9 +264,10 @@ func TestRouterSecurity(t *testing.T) {
 	err := json.Unmarshal(w.Body.Bytes(), &parsed)
 	assert.Nil(t, err)
 
-	assert.Equal(t, parsed["security"], map[string]interface{}{
-		"default": nil,
-	})
+	assert.Equal(t, parsed["security"], []interface{}{
+		map[string]interface{}{
+			"default": []interface{}{},
+		}})
 
 	assert.Equal(t, parsed["components"].(map[string]interface{})["securitySchemes"], map[string]interface{}{
 		"default": map[string]interface{}{


### PR DESCRIPTION
I misread some of the spec. Validators and some docs tools choke on this, so here's the fix. Based on:

http://spec.openapis.org/oas/v3.0.3.html#optional-oauth2-security

TL;DR: the structure is an array of objects, not an object. D'oh...