### PR TITLE
Code sync

### DIFF
--- a/autoconfig.go
+++ b/autoconfig.go
@@ -7,6 +7,10 @@ type AutoConfigVar struct {
 	Example     string        `json:"example,omitempty"`
 	Default     interface{}   `json:"default,omitempty"`
 	Enum        []interface{} `json:"enum,omitempty"`
+
+	// Exclude the value from being sent to the server. This essentially makes
+	// it a value which is only used in param templates.
+	Exclude bool `json:"exclude,omitempty"`
 }
 
 // AutoConfig holds an API's automatic configuration settings for the CLI. These

--- a/openapi.go
+++ b/openapi.go
@@ -73,9 +73,23 @@ func (c *oaComponents) AddSchema(t reflect.Type, mode schema.Mode, hint string) 
 		name = hint
 	}
 
-	s, err := schema.GenerateWithMode(t, mode, nil)
-	if err != nil {
-		panic(err)
+	var s *schema.Schema
+
+	if t.Kind() == reflect.Slice {
+		// We actually want to create two models: one for the container slice
+		// and one for the items within it.
+		ref := c.AddSchema(t.Elem(), mode, name+"Item")
+		s = &schema.Schema{
+			Type: schema.TypeArray,
+			Items: &schema.Schema{
+				Ref: ref,
+			},
+		}
+	} else {
+		var err error
+		if s, err = schema.GenerateWithMode(t, mode, nil); err != nil {
+			panic(err)
+		}
 	}
 
 	orig := name

--- a/router.go
+++ b/router.go
@@ -73,6 +73,10 @@ func (r *Router) OpenAPI() *gabs.Container {
 		doc.Set(r.description, "info", "description")
 	}
 
+	if len(r.servers) > 0 {
+		doc.Set(r.servers, "servers")
+	}
+
 	components := &oaComponents{
 		Schemas:         map[string]*schema.Schema{},
 		SecuritySchemes: r.securitySchemes,

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -144,13 +144,14 @@ type Schema struct {
 	WriteOnly            bool               `json:"writeOnly,omitempty"`
 	Deprecated           bool               `json:"deprecated,omitempty"`
 	ContentEncoding      string             `json:"contentEncoding,omitempty"`
+	Ref                  string             `json:"$ref,omitempty"`
 }
 
 // HasValidation returns true if at least one validator is set on the schema.
 // This excludes the schema's type but includes most other fields and can be
 // used to trigger additional slow validation steps when needed.
 func (s *Schema) HasValidation() bool {
-	if s.Items != nil || len(s.Properties) > 0 || s.AdditionalProperties != nil || len(s.PatternProperties) > 0 || len(s.Required) > 0 || len(s.Enum) > 0 || s.Minimum != nil || s.ExclusiveMinimum != nil || s.Maximum != nil || s.ExclusiveMaximum != nil || s.MultipleOf != 0 || s.MinLength != nil || s.MaxLength != nil || s.Pattern != "" || s.MinItems != nil || s.MaxItems != nil || s.UniqueItems || s.MinProperties != nil || s.MaxProperties != nil || len(s.AllOf) > 0 || len(s.AnyOf) > 0 || len(s.OneOf) > 0 || s.Not != nil {
+	if s.Items != nil || len(s.Properties) > 0 || s.AdditionalProperties != nil || len(s.PatternProperties) > 0 || len(s.Required) > 0 || len(s.Enum) > 0 || s.Minimum != nil || s.ExclusiveMinimum != nil || s.Maximum != nil || s.ExclusiveMaximum != nil || s.MultipleOf != 0 || s.MinLength != nil || s.MaxLength != nil || s.Pattern != "" || s.MinItems != nil || s.MaxItems != nil || s.UniqueItems || s.MinProperties != nil || s.MaxProperties != nil || len(s.AllOf) > 0 || len(s.AnyOf) > 0 || len(s.OneOf) > 0 || s.Not != nil || s.Ref != "" {
 		return true
 	}
 


### PR DESCRIPTION
Code sync from upstream open source project:

- Minor improvements to schema ref generation in OpenAPI
  - Request bodies are now refs and can be re-used
  - Lists now generate the list ref and a list item ref
  - Overall this generates nicer SDKs using OpenAPI Generator down the line
- Fix to include server list in OpenAPI properly
- CLI auto-configuration definition update for new param supported by Restish 0.5.1.