### PR TITLE
fix: exclusive min/max type should be bool when rendered into schema

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -123,9 +123,9 @@ type Schema struct {
 	Default              interface{}        `json:"default,omitempty"`
 	Example              interface{}        `json:"example,omitempty"`
 	Minimum              *float64           `json:"minimum,omitempty"`
-	ExclusiveMinimum     *float64           `json:"exclusiveMinimum,omitempty"`
+	ExclusiveMinimum     *bool              `json:"exclusiveMinimum,omitempty"`
 	Maximum              *float64           `json:"maximum,omitempty"`
-	ExclusiveMaximum     *float64           `json:"exclusiveMaximum,omitempty"`
+	ExclusiveMaximum     *bool              `json:"exclusiveMaximum,omitempty"`
 	MultipleOf           float64            `json:"multipleOf,omitempty"`
 	MinLength            *uint64            `json:"minLength,omitempty"`
 	MaxLength            *uint64            `json:"maxLength,omitempty"`
@@ -280,7 +280,9 @@ func GenerateFromField(f reflect.StructField, mode Mode) (string, bool, *Schema,
 		if err != nil {
 			return name, false, nil, err
 		}
-		s.ExclusiveMinimum = &min
+		s.Minimum = &min
+		t := true
+		s.ExclusiveMinimum = &t
 	}
 
 	if tag, ok := f.Tag.Lookup("maximum"); ok {
@@ -296,7 +298,9 @@ func GenerateFromField(f reflect.StructField, mode Mode) (string, bool, *Schema,
 		if err != nil {
 			return name, false, nil, err
 		}
-		s.ExclusiveMaximum = &max
+		s.Maximum = &max
+		t := true
+		s.ExclusiveMaximum = &t
 	}
 
 	if tag, ok := f.Tag.Lookup("multipleOf"); ok {

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -238,7 +238,8 @@ func TestSchemaExclusiveMinimum(t *testing.T) {
 
 	s, err := Generate(reflect.ValueOf(Example{}).Type())
 	assert.NoError(t, err)
-	assert.Equal(t, 1.0, *s.Properties["foo"].ExclusiveMinimum)
+	assert.Equal(t, 1.0, *s.Properties["foo"].Minimum)
+	assert.Equal(t, true, *s.Properties["foo"].ExclusiveMinimum)
 }
 
 func TestSchemaExclusiveMinimumError(t *testing.T) {
@@ -276,7 +277,8 @@ func TestSchemaExclusiveMaximum(t *testing.T) {
 
 	s, err := Generate(reflect.ValueOf(Example{}).Type())
 	assert.NoError(t, err)
-	assert.Equal(t, 0.0, *s.Properties["foo"].ExclusiveMaximum)
+	assert.Equal(t, 0.0, *s.Properties["foo"].Maximum)
+	assert.Equal(t, true, *s.Properties["foo"].ExclusiveMaximum)
 }
 
 func TestSchemaExclusiveMaximumError(t *testing.T) {


### PR DESCRIPTION
As specified in the [spec](http://spec.openapis.org/oas/v3.0.3.html#openapi-object):

> The following properties are taken directly from the JSON Schema definition and follow the same specifications:
> ...
> - exclusiveMaximum
> - exclusiveMinimum

OpenAPI 3.0.3 (latest) specifically uses JSON Schema Wright 00, which [says](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.3):

> The value of "exclusiveMaximum" MUST be a boolean, representing
   whether the limit in "maximum" is exclusive or not.  An undefined
   value is the same as false.
> 
> If "exclusiveMaximum" is true, then a numeric instance SHOULD NOT be
   equal to the value specified in "maximum".  If "exclusiveMaximum" is
   false (or not specified), then a numeric instance MAY be equal to the
   value of "maximum".

The newest JSON Schema does [support numbers](https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.6.2.3) but we can't use that until OpenAPI has been updated to align with it, which is currently in [release candidate](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#data-types) so will take some time to get adopted. I jumped the gun on that with my initial implementation :cry:

Why do we need this? Some tools validate the OpenAPI and will fail to parse it. For example, [Restish](https://rest.sh/) does this and reports an error when e.g. `exclusiveMaximum` gets used in validation. Either way we should want to spit out valid OpenAPI!

The behavior of the Go struct tags is kept the same to be ready for the OpenAPI 3.1 update without breaking people, plus it's just an easier way to specify it.