### PR TITLE
fix: better handling of enums for arrays

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -240,12 +240,23 @@ func GenerateFromField(f reflect.StructField, mode Mode) (string, bool, *Schema,
 
 	if tag, ok := f.Tag.Lookup("enum"); ok {
 		s.Enum = []interface{}{}
+
+		enumType := f.Type
+		enumSchema := s
+		if s.Type == TypeArray {
+			// Enum values should be the type of the array elements, not the
+			// array itself!
+			enumType = f.Type.Elem()
+			enumSchema = s.Items
+		}
+
 		for _, v := range strings.Split(tag, ",") {
-			parsed, err := getTagValue(s, f.Type, v)
+			parsed, err := getTagValue(enumSchema, enumType, v)
 			if err != nil {
 				return name, false, nil, err
 			}
-			s.Enum = append(s.Enum, parsed)
+
+			enumSchema.Enum = append(enumSchema.Enum, parsed)
 		}
 	}
 

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -116,6 +116,21 @@ func TestSchemaEnum(t *testing.T) {
 	assert.Equal(t, []interface{}{"one", "two", "three"}, s.Properties["foo"].Enum)
 }
 
+func TestSchemaArrayEnum(t *testing.T) {
+	type Example struct {
+		Foo []string `json:"foo" enum:"one,two,three"`
+	}
+
+	s, err := Generate(reflect.ValueOf(Example{}).Type())
+	assert.NoError(t, err)
+
+	// Array itself should not have an enum member set.
+	assert.Equal(t, []interface{}{}, s.Properties["foo"].Enum)
+
+	// Items in the array should be one of the allowed enum values.
+	assert.Equal(t, []interface{}{"one", "two", "three"}, s.Properties["foo"].Items.Enum)
+}
+
 func TestSchemaDefault(t *testing.T) {
 	type Example struct {
 		Foo string `json:"foo" default:"def"`


### PR DESCRIPTION
Small fix to enable documentation and validation of enum values contained in arrays. Arrays are a special case (particularly arrays of strings, which are used by [protoc-gen-huma](https://github.com/istreamlabs/protoc-gen-huma)) where we want to treat the enum as the allowed values *inside* the array rather than an enum of allowed arrays.