### PR TITLE
fix: use TrimPrefix instead of TrimLeft

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -71,8 +71,8 @@ func validAgainstSchema(ctx *hcontext, label string, schema *schema.Schema, data
 			// Note: some descriptions start with the context location so we trim
 			// those off to prevent duplicating data. (e.g. see the enum error)
 			ctx.AddError(&ErrorDetail{
-				Message:  strings.TrimLeft(desc.Description(), desc.Context().String()+" "),
-				Location: label + strings.TrimLeft(desc.Field(), "(root)"),
+				Message:  strings.TrimPrefix(desc.Description(), desc.Context().String()+" "),
+				Location: label + strings.TrimPrefix(desc.Field(), "(root)"),
 				Value:    desc.Value(),
 			})
 		}

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -19,7 +19,7 @@ func TestExhaustiveErrors(t *testing.T) {
 		Tags         []int     `query:"tags"`
 		Time         time.Time `query:"time"`
 		Body         struct {
-			Value int `json:"value" minimum:"5"`
+			Test int `json:"test" minimum:"5"`
 		}
 	}
 
@@ -30,10 +30,10 @@ func TestExhaustiveErrors(t *testing.T) {
 	})
 
 	w := httptest.NewRecorder()
-	r, _ := http.NewRequest(http.MethodGet, "/?bool=bad&int=bad&float32=bad&float64=bad&tags=1,2,bad&time=bad", strings.NewReader(`{"value": 1}`))
+	r, _ := http.NewRequest(http.MethodGet, "/?bool=bad&int=bad&float32=bad&float64=bad&tags=1,2,bad&time=bad", strings.NewReader(`{"test": 1}`))
 	app.ServeHTTP(w, r)
 
-	assert.JSONEq(t, `{"title":"Bad Request","status":400,"detail":"Error while parsing input parameters","errors":[{"message":"cannot parse boolean","location":"query.bool","value":"bad"},{"message":"cannot parse integer","location":"query.int","value":"bad"},{"message":"cannot parse float","location":"query.float32","value":"bad"},{"message":"cannot parse float","location":"query.float64","value":"bad"},{"message":"cannot parse integer","location":"query[2].tags","value":"bad"},{"message":"unable to validate against schema: invalid character 'b' looking for beginning of value","location":"query.tags","value":"[1,2,bad]"},{"message":"cannot parse time","location":"query.time","value":"bad"},{"message":"Must be greater than or equal to 5","location":"body.value","value":1}]}`, w.Body.String())
+	assert.JSONEq(t, `{"title":"Bad Request","status":400,"detail":"Error while parsing input parameters","errors":[{"message":"cannot parse boolean","location":"query.bool","value":"bad"},{"message":"cannot parse integer","location":"query.int","value":"bad"},{"message":"cannot parse float","location":"query.float32","value":"bad"},{"message":"cannot parse float","location":"query.float64","value":"bad"},{"message":"cannot parse integer","location":"query[2].tags","value":"bad"},{"message":"unable to validate against schema: invalid character 'b' looking for beginning of value","location":"query.tags","value":"[1,2,bad]"},{"message":"cannot parse time","location":"query.time","value":"bad"},{"message":"Must be greater than or equal to 5","location":"body.test","value":1}]}`, w.Body.String())
 }
 
 type Dep1 struct {


### PR DESCRIPTION
Tiny PR to use the correct trimming function. `TrimLeft` removes a prefix made up of characters in a given "cutset" while `TrimPrefix` removes the string prefix. This only triggered when one of the cutset members was at the start of a string. Example:

- Before: `body.ranscode.foo`
- After: `body.transcode.foo`

Whoops 😆 Test is updated to make sure to trigger the problem by starting the body field name with a `t`.