### PR TITLE
feat: add args parsed CLI hook

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -3,9 +3,12 @@ package cli
 import (
 	"context"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -31,4 +34,36 @@ func TestCLI(t *testing.T) {
 	app.Shutdown(ctx)
 
 	assert.Equal(t, true, started)
+}
+
+func TestParsedArgs(t *testing.T) {
+	app := NewRouter("Test API", "1.0.0")
+
+	foo := ""
+	app.Flag("foo", "f", "desc", "")
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	app.Root().AddCommand(&cobra.Command{
+		Use: "foo-test",
+		Run: func(cmd *cobra.Command, args []string) {
+			// Command does nothing...
+		},
+	})
+
+	app.ArgsParsed(func() {
+		foo = viper.GetString("foo")
+		wg.Done()
+	})
+
+	app.Root().SetArgs([]string{"foo-test", "--foo=bar"})
+
+	go func() {
+		app.Root().Execute()
+	}()
+
+	wg.Wait()
+
+	assert.Equal(t, "bar", foo)
 }


### PR DESCRIPTION
This proposal adds a new hook into the CLI to allow running of functions **after** arguments have been parsed but **before**  any command handler code runs. It works for *any* command, not just the default server startup.

This is useful to run setup or other code that requires arguments to have been parsed, e.g. reading the current environment name or settings that might modify the OpenAPI based on passed arguments before rendering the `openapi.yaml`.